### PR TITLE
Install command

### DIFF
--- a/cmtc/src/main/scala/cmt/client/Domain.scala
+++ b/cmtc/src/main/scala/cmt/client/Domain.scala
@@ -16,7 +16,7 @@ package cmt.client
 import cmt.{CmtError, FailedToValidateArgument, OptionName}
 import sbt.io.syntax.{File, file}
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 object Domain:
   final case class ExerciseId(value: String)
@@ -38,13 +38,11 @@ object Domain:
   object GithubCourseRef {
     def fromString(value: String): Either[CmtError, GithubCourseRef] = {
       Try {
-        val (organisation, project) = {
-          val split = value.split("/")
-          (split(0), split(1))
-        }
-      } {
+        val split = value.split("/")
+        (split(0), split(1))
+      } match {
         case Success((organisation, project)) => Right(new GithubCourseRef(organisation, project) {})
-        case Failure(error)                   => Left(FailedToValidateArgument.because("course", error.tost))
+        case Failure(error)                   => Left(FailedToValidateArgument.because("course", error.getMessage))
       }
 
     }

--- a/cmtc/src/main/scala/cmt/client/Domain.scala
+++ b/cmtc/src/main/scala/cmt/client/Domain.scala
@@ -44,7 +44,7 @@ object Domain:
         }
       } {
         case Success((organisation, project)) => Right(new GithubCourseRef(organisation, project) {})
-        case Failure(error) => Left(FailedToValidateArgument.because("course", error.tost))
+        case Failure(error)                   => Left(FailedToValidateArgument.because("course", error.tost))
       }
 
     }

--- a/cmtc/src/main/scala/cmt/client/Domain.scala
+++ b/cmtc/src/main/scala/cmt/client/Domain.scala
@@ -44,6 +44,5 @@ object Domain:
         case Success((organisation, project)) => Right(new GithubCourseRef(organisation, project) {})
         case Failure(error)                   => Left(FailedToValidateArgument.because("course", error.getMessage))
       }
-
     }
   }

--- a/cmtc/src/main/scala/cmt/client/Domain.scala
+++ b/cmtc/src/main/scala/cmt/client/Domain.scala
@@ -28,3 +28,10 @@ object Domain:
   final case class TemplatePath(value: String)
   object TemplatePath:
     val default: TemplatePath = TemplatePath("")
+
+  final case class GithubCourseRef(value: String) {
+    val (organisation, project) = {
+      val split = value.split("/")
+      (split(0), split(1))
+    }
+  }

--- a/cmtc/src/main/scala/cmt/client/Main.scala
+++ b/cmtc/src/main/scala/cmt/client/Main.scala
@@ -17,6 +17,7 @@ import caseapp.core.app.{Command, CommandsEntryPoint}
 import cmt.client.command.{
   GotoExercise,
   GotoFirstExercise,
+  Install,
   ListExercises,
   ListSavedStates,
   NextExercise,
@@ -33,6 +34,7 @@ object Main extends CommandsEntryPoint:
     Seq(
       GotoExercise.command,
       GotoFirstExercise.command,
+      Install.command,
       ListExercises.command,
       ListSavedStates.command,
       NextExercise.command,

--- a/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
+++ b/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
@@ -1,6 +1,7 @@
 package cmt.client.cli
 
 import caseapp.core.Error
+import caseapp.core.Error.Other
 import caseapp.core.argparser.{ArgParser, FlagArgParser, SimpleArgParser}
 import cmt.client.Domain.{ExerciseId, ForceMoveToExercise, GithubCourseRef, StudentifiedRepo, TemplatePath}
 import sbt.io.syntax.{File, file}
@@ -32,5 +33,5 @@ object ArgParsers {
     SimpleArgParser.from[TemplatePath]("template path")(TemplatePath(_).asRight)
 
   implicit val githubCourseRefArgParser: ArgParser[GithubCourseRef] =
-    SimpleArgParser.from[GithubCourseRef]("github course ref")(GithubCourseRef(_).asRight)
+    SimpleArgParser.string.xmapError[GithubCourseRef](_.asString(), str => GithubCourseRef.fromString(str).leftMap(error => Error.Other(error.prettyPrint)))
 }

--- a/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
+++ b/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
@@ -33,5 +33,7 @@ object ArgParsers {
     SimpleArgParser.from[TemplatePath]("template path")(TemplatePath(_).asRight)
 
   implicit val githubCourseRefArgParser: ArgParser[GithubCourseRef] =
-    SimpleArgParser.string.xmapError[GithubCourseRef](_.asString(), str => GithubCourseRef.fromString(str).leftMap(error => Error.Other(error.prettyPrint)))
+    SimpleArgParser.string.xmapError[GithubCourseRef](
+      _.asString(),
+      str => GithubCourseRef.fromString(str).leftMap(error => Error.Other(error.prettyPrint)))
 }

--- a/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
+++ b/cmtc/src/main/scala/cmt/client/cli/ArgParsers.scala
@@ -2,7 +2,7 @@ package cmt.client.cli
 
 import caseapp.core.Error
 import caseapp.core.argparser.{ArgParser, FlagArgParser, SimpleArgParser}
-import cmt.client.Domain.{ExerciseId, ForceMoveToExercise, StudentifiedRepo, TemplatePath}
+import cmt.client.Domain.{ExerciseId, ForceMoveToExercise, GithubCourseRef, StudentifiedRepo, TemplatePath}
 import sbt.io.syntax.{File, file}
 import cats.syntax.apply.*
 import cats.syntax.either.*
@@ -30,4 +30,7 @@ object ArgParsers {
 
   implicit val templatePathArgParser: ArgParser[TemplatePath] =
     SimpleArgParser.from[TemplatePath]("template path")(TemplatePath(_).asRight)
+
+  implicit val githubCourseRefArgParser: ArgParser[GithubCourseRef] =
+    SimpleArgParser.from[GithubCourseRef]("github course ref")(GithubCourseRef(_).asRight)
 }

--- a/cmtc/src/main/scala/cmt/client/cli/CmtcCommand.scala
+++ b/cmtc/src/main/scala/cmt/client/cli/CmtcCommand.scala
@@ -1,0 +1,16 @@
+package cmt.client.cli
+
+import caseapp.core.help.Help
+import caseapp.core.parser.Parser
+import cmt.printErrorAndExit
+import cmt.client.Configuration
+import cmt.core.cli.CmtCommand
+import cats.syntax.either.*
+
+abstract class CmtcCommand[T](implicit parser: Parser[T], help: Help[T]) extends CmtCommand[T] {
+
+  protected val configuration = Configuration
+    .load()
+    .leftMap(error => printErrorAndExit(error.prettyPrint))
+    .getOrElse(printErrorAndExit("failed to load configuration"))
+}

--- a/cmtc/src/main/scala/cmt/client/command/Executable.scala
+++ b/cmtc/src/main/scala/cmt/client/command/Executable.scala
@@ -1,0 +1,7 @@
+package cmt.client.command
+
+import cmt.CmtError
+import cmt.client.Configuration
+
+trait Executable[T]:
+  extension (t: T) def execute(configuration: Configuration): Either[CmtError, String]

--- a/cmtc/src/main/scala/cmt/client/command/Install.scala
+++ b/cmtc/src/main/scala/cmt/client/command/Install.scala
@@ -34,7 +34,7 @@ object Install:
         printMessage(s"Installing course '${cmd.course}' into '${configuration.coursesDirectory}'")
         val workingDir = configuration.coursesDirectory.value / cmd.course.organisation / cmd.course.project
         sbtio.createDirectory(workingDir)
-        val cloneCommand = s"git clone git@github.com:${cmd.course.value}.git".toProcessCmd(workingDir)
+        val cloneCommand = s"git clone git@github.com:${cmd.course.asString()}.git".toProcessCmd(workingDir)
         cloneCommand.runAndReadOutput()
       }
     end extension

--- a/cmtc/src/main/scala/cmt/client/command/Install.scala
+++ b/cmtc/src/main/scala/cmt/client/command/Install.scala
@@ -12,6 +12,7 @@ import cats.syntax.either.*
 import sbt.io.syntax.*
 import sbt.io.IO as sbtio
 import cmt.ProcessDSL.{ProcessCmd, runAndReadOutput, toProcessCmd}
+import cmt.core.cli.enforceNoTrailingArguments
 
 object Install:
 
@@ -42,9 +43,11 @@ object Install:
 
   val command = new CmtcCommand[Install.Options] {
 
-    def run(options: Install.Options, args: RemainingArgs): Unit = {
-      options.validated().flatMap(_.execute(configuration)).printResult()
-    }
+    def run(options: Install.Options, args: RemainingArgs): Unit =
+      args
+        .enforceNoTrailingArguments()
+        .flatMap(_ => options.validated().flatMap(_.execute(configuration)))
+        .printResult()
   }
 
 end Install

--- a/cmtc/src/main/scala/cmt/client/command/Install.scala
+++ b/cmtc/src/main/scala/cmt/client/command/Install.scala
@@ -1,0 +1,50 @@
+package cmt.client.command
+
+import caseapp.{AppName, CommandName, ExtraName, Recurse, RemainingArgs}
+import cmt.client.Configuration
+import cmt.client.Domain.GithubCourseRef
+import cmt.{CMTcConfig, CmtError, ProcessDSL, printErrorAndExit, printMessage, printResult}
+import cmt.client.cli.{CmtcCommand, SharedOptions}
+import cmt.client.command.Executable
+import cmt.core.validation.Validatable
+import cmt.client.cli.ArgParsers.githubCourseRefArgParser
+import cats.syntax.either.*
+import sbt.io.syntax.*
+import sbt.io.IO as sbtio
+import cmt.ProcessDSL.{ProcessCmd, runAndReadOutput, toProcessCmd}
+
+object Install:
+
+  @AppName("install")
+  @CommandName("install")
+  final case class Options(
+      @ExtraName("c")
+      course: GithubCourseRef)
+
+  given Validatable[Install.Options] with
+    extension (options: Install.Options)
+      def validated(): Either[CmtError, Install.Options] =
+        Right(options)
+      end validated
+  end given
+
+  given Executable[Install.Options] with
+    extension (cmd: Install.Options)
+      def execute(configuration: Configuration): Either[CmtError, String] = {
+        printMessage(s"Installing course '${cmd.course}' into '${configuration.coursesDirectory}'")
+        val workingDir = configuration.coursesDirectory.value / cmd.course.organisation / cmd.course.project
+        sbtio.createDirectory(workingDir)
+        val cloneCommand = s"git clone git@github.com:${cmd.course.value}.git".toProcessCmd(workingDir)
+        cloneCommand.runAndReadOutput()
+      }
+    end extension
+  end given
+
+  val command = new CmtcCommand[Install.Options] {
+
+    def run(options: Install.Options, args: RemainingArgs): Unit = {
+      options.validated().flatMap(_.execute(configuration)).printResult()
+    }
+  }
+
+end Install


### PR DESCRIPTION
Added the install command. This has required a little bit of gymnastics to get the global configuration to be injected into the command execution.

I've created a `cmtc`-specific `Executable` that allows the `Configuration` to be injected via the `execute(configuration)` method... this feels better than combining the `Configuration` with the `Install.Options`.

The `install` method just does a `git clone`. This means i need to add validation on the github project that's provided as the `--course, -c` option to `cmtc install` - as we need it to be of the form `organisation/project` so we can build the Github command from it.