### PR TITLE
Add missing short option name to move between exercises commands

### DIFF
--- a/cmtc/src/main/scala/cmt/client/command/GotoFirstExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/GotoFirstExercise.scala
@@ -15,6 +15,7 @@ object GotoFirstExercise:
   @CommandName("goto-first-exercise")
   @HelpMessage("Move to the first exercise. Pull in tests and readme files for that exercise")
   final case class Options(
+      @ExtraName("f")
       force: ForceMoveToExercise = ForceMoveToExercise(false),
       @ExtraName("s")
       studentifiedRepo: Option[StudentifiedRepo] = None)

--- a/cmtc/src/main/scala/cmt/client/command/NextExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/NextExercise.scala
@@ -18,6 +18,7 @@ object NextExercise:
   @CommandName("next-exercise")
   @HelpMessage("Move to the next exercise. Pull in tests and readme files for that exercise")
   final case class Options(
+      @ExtraName("f")
       force: ForceMoveToExercise = ForceMoveToExercise(false),
       @ExtraName("s")
       studentifiedRepo: Option[StudentifiedRepo] = None)

--- a/cmtc/src/main/scala/cmt/client/command/PreviousExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/PreviousExercise.scala
@@ -18,6 +18,7 @@ object PreviousExercise:
   @CommandName("previous-exercise")
   @HelpMessage("Move to the previous exercise. Pull in tests and readme files for that exercise")
   final case class Options(
+      @ExtraName("f")
       force: ForceMoveToExercise = ForceMoveToExercise(false),
       @ExtraName("s")
       studentifiedRepo: Option[StudentifiedRepo] = None)


### PR DESCRIPTION
- Three commands were missing the `-d` force move short option name