### PR TITLE
Fix issue with exercises in root folder studentified repo

### DIFF
--- a/core/src/main/scala/com/lunatech/cmt/Helpers.scala
+++ b/core/src/main/scala/com/lunatech/cmt/Helpers.scala
@@ -167,6 +167,14 @@ object Helpers:
     import java.nio.file.Files
     val _ = Files.write(file.toPath, string.getBytes(StandardCharsets.UTF_8))
 
+  private def dontTouchExtraFiles(config: CMTaConfig): List[String] =
+    if config.studentifiedRepoActiveExerciseFolder == "." then List(".cmt", ".git", ".gitignore")
+    else List.empty[String]
+
+  private def dontTouchFilesAdjust(config: CMTaConfig, path: String): String =
+    if config.studentifiedRepoActiveExerciseFolder == "." then path
+    else s"${config.studentifiedRepoActiveExerciseFolder}/${path}"
+
   def writeStudentifiedCMTConfig(configFile: File, exercises: Seq[String])(
       config: CMTaConfig,
       generatorInfo: GeneratorInfo): Unit =
@@ -183,9 +191,8 @@ object Helpers:
       "test-code-folders" -> config.testCodeFolders.asJava,
       "read-me-files" -> config.readMeFiles.asJava,
       "exercises" -> exercises.asJava,
-      "cmt-studentified-dont-touch" -> config.cmtStudentifiedDontTouch
-        .map(path => s"${config.studentifiedRepoActiveExerciseFolder}/${path}")
-        .asJava)
+      "cmt-studentified-dont-touch" -> (config.cmtStudentifiedDontTouch.map(path =>
+        dontTouchFilesAdjust(config, path)) ++ dontTouchExtraFiles(config)).asJava)
     val cmtConfig =
       ConfigFactory.parseMap(configMap.asJava).root().render(ConfigRenderOptions.concise().setFormatted(true))
     dumpStringToFile(cmtConfig, configFile)


### PR DESCRIPTION
When CMT configuration setting `studentified-repo-active-exercise-folder` is set to `"."`, the exercise code is put in the root folder of the studentified artefact when studentifying a course.

This commit fixes the problem that overwrote the CMT configuration folder in the studentified artifact. The fix consists of tuning the `cmt-studentified-dont-touch` configuration setting in the studentified artifact.

For example, with this main CMT configuration file:

```
  studentified-repo-active-exercise-folder = code

  cmt-studentified-dont-touch = [
    .idea
    .bsp
    .bloop
    .vscode
    .metals
    project/target
    project/project
  ]
```

the resulting studentified artifact configuration settings are:

```
    "active-exercise-folder" : "code",
    "cmt-studentified-dont-touch" : [
        "code/.idea",
        "code/.bsp",
        "code/.bloop",
        "code/.vscode",
        "code/.metals",
        "code/project/target",
        "code/project/project"
    ],
```

In contrast, with the following config file:

```
  studentified-repo-active-exercise-folder = .

  cmt-studentified-dont-touch = [
    .idea
    .bsp
    .bloop
    .vscode
    .metals
    project/target
    project/project
  ],
```

the resulting studentified artifact configuration settings look as follows:

```
    "active-exercise-folder" : ".",
    "cmt-studentified-dont-touch" : [
        ".idea",
        ".bsp",
        ".bloop",
        ".vscode",
        ".metals",
        "project/target",
        "project/project",
        ".cmt",
        ".git",
        ".gitignore"
    ],
```