### PR TITLE
refactor(ci): just use the default cloned course-management-tools dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout Course Management Tools Repo
         uses: actions/checkout@v3
         with:
-          path: CMT
           fetch-depth: 0
 
       - name: Set up JDK 11
@@ -35,14 +34,10 @@ jobs:
           ./coursier
 
       - name: Check code formatting
-        run: |
-          cd CMT &&
-          sbt "scalafmtCheckAll ; scalafmtSbtCheck"
+        run: sbt "scalafmtCheckAll ; scalafmtSbtCheck"
 
       - name: Run tests
-        run: |
-          cd CMT &&
-          sbt test
+        run: sbt test
 
   run-tests-windows:
     runs-on: windows-latest
@@ -52,7 +47,6 @@ jobs:
       - name: Checkout Course Management Tools Repo
         uses: actions/checkout@v3
         with:
-          path: CMT
           fetch-depth: 0
 
       - name: Set up JDK 11
@@ -64,9 +58,7 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: |
-          cd CMT &&
-          sbt test
+        run: sbt test
 
   create-release:
     runs-on: ubuntu-latest
@@ -78,7 +70,6 @@ jobs:
       - name: Checkout Course Management Tools Repo
         uses: actions/checkout@v3
         with:
-          path: CMT
           fetch-depth: 0
 
       - name: Set up JDK 11
@@ -95,7 +86,7 @@ jobs:
           ./coursier
 
       - name: Publish Local
-        run: (cd CMT && exec sbt publishLocal)
+        run: sbt publishLocal
           
       - name: Package Binaries
         run: |


### PR DESCRIPTION
Unless I'm misunderstanding something, we don't need this `CMT` abstraction right? Can't we just rely on the checked out dir that is created when it clones and we can avoid having the `cd CMT` in various places?