### PR TITLE
Generate native images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,33 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        include:
+          - os: macOS-latest
+            uploaded_filename_cmta: cmta-x86_64-apple-darwin
+            local_path_cmta: cmta/target/native-image/cmta
+            uploaded_filename_cmtc: cmtc-x86_64-apple-darwin
+            local_path_cmtc: cmtc/target/native-image/cmtc
+          - os: ubuntu-latest
+            uploaded_filename_cmta: cmta-x86_64-pc-linux
+            local_path_cmta: cmta/target/native-image/cmta
+            uploaded_filename_cmtc: cmtc-x86_64-pc-linux
+            local_path_cmtc: cmtc/target/native-image/cmtc
+          # - os: windows-latest
+          #   uploaded_filename_cmta: cmta-x86_64-pc-win32.exe
+          #   local_path_cmta: cmta\target\native-image\cmta
+          #   uploaded_filename_cmtc: cmtc-x86_64-pc-win32.exe
+          #   local_path_cmtc: cmtc\target\native-image\cmtc
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+
+    env:
+      # define Java options for both official sbt and sbt-extras
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
 
@@ -39,6 +64,7 @@ jobs:
 
       - name: Publish Local
         run: sbt publishLocal
+        if: ${{ matrix.os == 'ubuntu-latest' }}
           
       - name: Package Binaries
         run: |
@@ -46,6 +72,7 @@ jobs:
           ./coursier bootstrap com.lunatech:cmta_3:${{ env.RELEASE_VERSION }} -o course-management-tools/bin/cmta --standalone --bat
           ./coursier bootstrap com.lunatech:cmtc_3:${{ env.RELEASE_VERSION }} -o course-management-tools/bin/cmtc --standalone --bat
           zip -r course-management-tools.zip course-management-tools
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - run: sbt ci-release
         env:
@@ -53,6 +80,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Create Github Release
         id: create_release
@@ -64,6 +92,7 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Upload assets to Github release
         uses: actions/upload-release-asset@v1
@@ -73,4 +102,44 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./course-management-tools.zip
           asset_name: course-management-tools.zip
+          asset_content_type: application/zip
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - name: Setup Windows C++ toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os == 'windows-latest' }}
+
+      - name: Native image generation
+        shell: bash
+        run: |
+          echo $(pwd)
+          sbt clean nativeImage
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.local_path_cmta }}
+          name: ${{ matrix.uploaded_filename_cmta }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.local_path_cmtc }}
+          name: ${{ matrix.uploaded_filename_cmtc }}
+
+      - name: Upload release cmta native
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ matrix.local_path_cmta }}
+          asset_name: ${{ matrix.uploaded_filename_cmta }}
+          asset_content_type: application/zip
+
+      - name: Upload release cmtc native
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ matrix.local_path_cmtc }}
+          asset_name: ${{ matrix.uploaded_filename_cmtc }}
           asset_content_type: application/zip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,8 +37,8 @@ jobs:
       - name: cmta check native image generation
         shell: bash
         run: sbt cmta/nativeImage
-        env:
-          NATIVE_IMAGE_INSTALLED: true
+        #env:
+        #  NATIVE_IMAGE_INSTALLED: true
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,9 +34,9 @@ jobs:
         shell: bash
         run: sbt test
 
-      - name: Check native image generation
+      - name: cmta check native image generation
         shell: bash
-        run: sbt nativeImage
+        run: sbt cmta/nativeImage
         env:
           NATIVE_IMAGE_INSTALLED: true
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
 
@@ -21,12 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK
+        uses: coursier/setup-action@v1
         with:
-          java-version: 11
-          distribution: adopt-hotspot
-          cache: 'sbt'
+          jvm: graalvm-java17:22.3.1
+
+      - name: Set up caching
+        uses: coursier/cache-action@v6
 
       - name: Run tests
         shell: bash
@@ -35,6 +37,8 @@ jobs:
       - name: Check native image generation
         shell: bash
         run: sbt nativeImage
+        env:
+          NATIVE_IMAGE_INSTALLED: true
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,19 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
         os: [ 'ubuntu-latest', 'macos-latest' ]
         include:
-          # Replace "example" with the name your binary
-          # - os: macOS-latest
-          #   uploaded_filename: cmta-x86_64-apple-darwin
-          #   local_path: cmta/target/native-image/cmta
+          - os: macOS-latest
+            uploaded_filename_cmta: cmta-x86_64-apple-darwin
+            local_path_cmta: cmta/target/native-image/cmta
+            uploaded_filename_cmtc: cmtc-x86_64-apple-darwin
+            local_path_cmtc: cmtc/target/native-image/cmtc
           - os: ubuntu-latest
-            uploaded_filename: cmta-x86_64-pc-linux
-            local_path: cmta/target/native-image/cmta
-          - os: windows-latest
-            uploaded_filename: cmta-x86_64-pc-win32.exe
-            local_path: cmta\target\native-image\cmta.exe
+            uploaded_filename_cmta: cmta-x86_64-pc-linux
+            local_path_cmta: cmta/target/native-image/cmta
+            uploaded_filename_cmtc: cmtc-x86_64-pc-linux
+            local_path_cmtc: cmtc/target/native-image/cmtc
+          # - os: windows-latest
+          #   uploaded_filename_cmta: cmta-x86_64-pc-win32.exe
+          #   local_path_cmta: cmta\target\native-image\cmta
+          #   uploaded_filename_cmtc: cmtc-x86_64-pc-win32.exe
+          #   local_path_cmtc: cmtc\target\native-image\cmtc
 
     env:
       # define Java options for both official sbt and sbt-extras
@@ -46,6 +50,8 @@ jobs:
           java-version: 11
           cache: sbt
 
+      - run: git fetch --tags || true
+
       - name: Set up caching
         uses: coursier/cache-action@v6
 
@@ -61,7 +67,16 @@ jobs:
         shell: bash
         run: |
           echo $(pwd)
-          sbt nativeImage
+          sbt clean nativeImage
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.local_path_cmta }}
+          name: ${{ matrix.uploaded_filename_cmta }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.local_path_cmtc }}
+          name: ${{ matrix.uploaded_filename_cmtc }}
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         #os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest', 'macos-latest' ]
         include:
           # Replace "example" with the name your binary
           # - os: macOS-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,33 +9,12 @@ permissions:
   contents: write
 
 jobs:
-  native-image:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
-        include:
-          - os: macOS-latest
-            uploaded_filename_cmta: cmta-x86_64-apple-darwin
-            local_path_cmta: cmta/target/native-image/cmta
-            uploaded_filename_cmtc: cmtc-x86_64-apple-darwin
-            local_path_cmtc: cmtc/target/native-image/cmtc
-          - os: ubuntu-latest
-            uploaded_filename_cmta: cmta-x86_64-pc-linux
-            local_path_cmta: cmta/target/native-image/cmta
-            uploaded_filename_cmtc: cmtc-x86_64-pc-linux
-            local_path_cmtc: cmtc/target/native-image/cmtc
-          # - os: windows-latest
-          #   uploaded_filename_cmta: cmta-x86_64-pc-win32.exe
-          #   local_path_cmta: cmta\target\native-image\cmta
-          #   uploaded_filename_cmtc: cmtc-x86_64-pc-win32.exe
-          #   local_path_cmtc: cmtc\target\native-image\cmtc
-
-    env:
-      # define Java options for both official sbt and sbt-extras
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout Course Management Tools Repo
@@ -50,33 +29,9 @@ jobs:
           java-version: 11
           cache: sbt
 
-      - run: git fetch --tags || true
-
-      - name: Set up caching
-        uses: coursier/cache-action@v6
-
-      #- name: Run tests
-      #  shell: bash
-      #  run: sbt test
-
-      - name: Setup Windows C++ toolchain
-        uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ matrix.os == 'windows-latest' }}
-
-      - name: Native image generation
+      - name: Run tests
         shell: bash
-        run: |
-          echo $(pwd)
-          sbt clean nativeImage
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ${{ matrix.local_path_cmta }}
-          name: ${{ matrix.uploaded_filename_cmta }}
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ${{ matrix.local_path_cmtc }}
-          name: ${{ matrix.uploaded_filename_cmtc }}
+        run: sbt test
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,13 +9,29 @@ permissions:
   contents: write
 
 jobs:
-  test:
+  native-image:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         #os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
         os: [ 'ubuntu-latest', 'windows-latest' ]
+        include:
+          # Replace "example" with the name your binary
+          # - os: macOS-latest
+          #   uploaded_filename: cmta-x86_64-apple-darwin
+          #   local_path: cmta/target/native-image/cmta
+          - os: ubuntu-latest
+            uploaded_filename: cmta-x86_64-pc-linux
+            local_path: cmta/target/native-image/cmta
+          - os: windows-latest
+            uploaded_filename: cmta-x86_64-pc-win32.exe
+            local_path: cmta\target\native-image\cmta.exe
+
+    env:
+      # define Java options for both official sbt and sbt-extras
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout Course Management Tools Repo
@@ -35,13 +51,14 @@ jobs:
       #  shell: bash
       #  run: sbt test
 
-      - uses: actions/checkout@v3
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Setup Windows C++ toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os == 'windows-latest' }}
+
       - name: Native image generation
         shell: bash
         run: |
-          cmake -G "NMake Makefiles" .
-          nmake
+          echo $(pwd)
           sbt nativeImage
 
   formatting:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,9 +40,11 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: coursier/setup-action@v1
+        uses: actions/setup-java@v3
         with:
-          jvm: graalvm-java17:22.3.1
+          distribution: temurin
+          java-version: 11
+          cache: sbt
 
       - name: Set up caching
         uses: coursier/cache-action@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,17 +31,18 @@ jobs:
       - name: Set up caching
         uses: coursier/cache-action@v6
 
-      - name: Windows dev environment
-        uses: microsoft/setup-msbuild@v1.1
-        if: runner.os == 'Windows'
-
       #- name: Run tests
       #  shell: bash
       #  run: sbt test
 
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Native image generation
         shell: bash
-        run: sbt nativeImage
+        run: |
+          cmake -G "NMake Makefiles" .
+          nmake
+          sbt nativeImage
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
 
     steps:
       - name: Checkout Course Management Tools Repo
@@ -28,9 +28,27 @@ jobs:
           distribution: adopt-hotspot
           cache: 'sbt'
 
-      - name: Check code formatting
-        run: sbt "scalafmtCheckAll ; scalafmtSbtCheck"
-
       - name: Run tests
         shell: bash
         run: sbt test
+
+      - name: Check native image generation
+        shell: bash
+        run: sbt nativeImage
+
+  formatting:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Checkout Course Management Tools Repo
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: adopt-hotspot
+          cache: 'sbt'
+
+      - name: Check code formatting
+        run: sbt "scalafmtCheckAll ; scalafmtSbtCheck"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        #os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
 
     steps:
       - name: Checkout Course Management Tools Repo
@@ -30,15 +31,17 @@ jobs:
       - name: Set up caching
         uses: coursier/cache-action@v6
 
-      - name: Run tests
-        shell: bash
-        run: sbt test
+      - name: Windows dev environment
+        uses: microsoft/setup-msbuild@v1.1
+        if: runner.os == 'Windows'
 
-      - name: cmta check native image generation
+      #- name: Run tests
+      #  shell: bash
+      #  run: sbt test
+
+      - name: Native image generation
         shell: bash
-        run: sbt cmta/nativeImage
-        #env:
-        #  NATIVE_IMAGE_INSTALLED: true
+        run: sbt nativeImage
 
   formatting:
     runs-on: 'ubuntu-latest'

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val cmta = project
   .enablePlugins(NativeImagePlugin)
   .dependsOn(`cmt-core`, `cmt-core` % "test->test")
   .settings(commonSettings: _*)
+  .settings(nativeImageSettings: _*)
   .settings(Compile / mainClass := Some("com.lunatech.cmt.admin.Main"))
   .settings(buildInfoKeys := buildKeysWithName("cmta:Course Management Tools (Admin)"))
 
@@ -40,6 +41,7 @@ lazy val cmtc = project
   .enablePlugins(NativeImagePlugin)
   .dependsOn(`cmt-core`, `cmt-core` % "test->test")
   .settings(commonSettings: _*)
+  .settings(nativeImageSettings: _*)
   .settings(libraryDependencies ++= Dependencies.cmtcDependencies)
   .settings(Compile / mainClass := Some("com.lunatech.cmt.client.Main"))
   .settings(buildInfoKeys := buildKeysWithName("Course Management Tools (Client)"))

--- a/cmta/src/main/resources/reflect-config.json
+++ b/cmta/src/main/resources/reflect-config.json
@@ -1,0 +1,93 @@
+[
+{
+  "name":"[Lcaseapp.core.util.fansi.Attr;"
+},
+{
+  "name":"[Lcaseapp.core.util.fansi.Category;"
+},
+{
+  "name":"[Ljava.lang.String;"
+},
+{
+  "name":"[[Ljava.lang.Object;"
+},
+{
+  "name":"caseapp.core.app.CaseApp",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
+  "name":"caseapp.core.parser.ParserCompanion",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
+  "name":"caseapp.core.util.fansi.Category",
+  "fields":[{"name":"0bitmap$2"}]
+},
+{
+  "name":"caseapp.core.util.fansi.Str",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
+  "name":"com.lunatech.cmt.admin.cli.ArgParsers$",
+  "fields":[
+    {"name":"configurationFileArgParser$lzy1"}, 
+    {"name":"courseTemplateArgParser$lzy1"}, 
+    {"name":"exerciseNumberArgParser$lzy1"}, 
+    {"name":"forceDeleteDestinationDirectoryArgParser$lzy1"}, 
+    {"name":"initializeGitRepoArgParser$lzy1"}, 
+    {"name":"linearizeBaseDirectoryArgParser$lzy1"}, 
+    {"name":"mainRepositoryArgParser$lzy1"}, 
+    {"name":"renumberOffsetArgParser$lzy1"}, 
+    {"name":"renumberStartArgParser$lzy1"}, 
+    {"name":"renumberStepArgParser$lzy1"}, 
+    {"name":"studentifyBaseDirectoryArgParser$lzy1"}
+  ]
+},
+{
+  "name":"com.lunatech.cmt.admin.cli.SharedOptions$",
+  "fields":[
+    {"name":"help$lzy1"}, 
+    {"name":"parser$lzy1"}
+  ]
+},
+{
+  "name":"java.lang.ClassValue"
+},
+{
+  "name":"java.lang.invoke.VarHandle",
+  "methods":[{"name":"releaseFence","parameterTypes":[] }]
+},
+{
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "name":"sbt.internal.io.Retry$",
+  "fields":[{"name":"limit$lzy1"}]
+},
+{
+  "name":"sbt.io.IO$",
+  "fields":[
+    {"name":"hasAclFileAttributeView$lzy1"}, 
+    {"name":"hasBasicFileAttributeView$lzy1"}, 
+    {"name":"hasDosFileAttributeView$lzy1"}, 
+    {"name":"hasFileOwnerAttributeView$lzy1"}, 
+    {"name":"hasPosixFileAttributeView$lzy1"}, 
+    {"name":"hasUserDefinedFileAttributeView$lzy1"}, 
+    {"name":"jrtFs$lzy1"}, 
+    {"name":"random$lzy1"}, 
+    {"name":"supportedFileAttributeViews$lzy1"}
+  ]
+},
+{
+  "name":"sun.misc.Unsafe",
+  "fields":[{"name":"theUnsafe"}]
+},
+{
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/cmta/src/main/resources/resource-config.json
+++ b/cmta/src/main/resources/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources":{
+  "includes":[
+    {
+      "pattern":"\\Qnative/x86_64/libswoval-files0.dylib\\E"
+    },
+    {
+      "pattern":"\\Qreference.conf\\E"
+    }
+  ]},
+  "bundles":[]
+}

--- a/cmtc/src/main/resources/reflect-config.json
+++ b/cmtc/src/main/resources/reflect-config.json
@@ -1,0 +1,286 @@
+[
+{
+  "name":"[B"
+},
+{
+  "name":"[Ljava.lang.String;"
+},
+{
+  "name":"[Lsun.security.pkcs.SignerInfo;"
+},
+{
+  "name":"apple.security.AppleProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"caseapp.core.app.CaseApp",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
+  "name":"caseapp.core.parser.ParserCompanion",
+  "fields":[{"name":"0bitmap$1"}]
+},
+{
+  "name":"com.lunatech.cmt.client.cli.ArgParsers$",
+  "fields":[
+    {"name":"exerciseIdArgParser$lzy1"}, 
+    {"name":"forceDeleteDestinationDirectoryArgParser$lzy1"}, 
+    {"name":"forceMoveToExerciseArgParser$lzy1"}, 
+    {"name":"templatePathArgParser$lzy1"}
+  ]
+},
+{
+  "name":"com.lunatech.cmt.core.cli.ArgParsers$",
+  "fields":[
+    {"name":"installationSourceArgParser$lzy1"}, 
+    {"name":"studentifiedRepoArgParser$lzy1"}
+  ]
+},
+{
+  "name":"com.sun.crypto.provider.AESCipher$General",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.ARCFOURCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.DESCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.DESedeCipher",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.DHParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.GaloisCounterMode$AESGCM",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"com.sun.crypto.provider.TlsMasterSecretGenerator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.ClassValue"
+},
+{
+  "name":"java.lang.String"
+},
+{
+  "name":"java.lang.invoke.VarHandle",
+  "methods":[{"name":"releaseFence","parameterTypes":[] }]
+},
+{
+  "name":"java.security.AlgorithmParametersSpi"
+},
+{
+  "name":"java.security.KeyStoreSpi"
+},
+{
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "name":"java.security.interfaces.ECPrivateKey"
+},
+{
+  "name":"java.security.interfaces.ECPublicKey"
+},
+{
+  "name":"java.security.interfaces.RSAPrivateKey"
+},
+{
+  "name":"java.security.interfaces.RSAPublicKey"
+},
+{
+  "name":"java.util.Date"
+},
+{
+  "name":"javax.security.auth.x500.X500Principal",
+  "fields":[{"name":"thisX500Name"}],
+  "methods":[{"name":"<init>","parameterTypes":["sun.security.x509.X500Name"] }]
+},
+{
+  "name":"sbt.internal.io.Retry$",
+  "fields":[{"name":"limit$lzy1"}]
+},
+{
+  "name":"sbt.io.IO$",
+  "fields":[
+    {"name":"hasAclFileAttributeView$lzy1"}, 
+    {"name":"hasBasicFileAttributeView$lzy1"}, 
+    {"name":"hasDosFileAttributeView$lzy1"}, 
+    {"name":"hasFileOwnerAttributeView$lzy1"}, 
+    {"name":"hasPosixFileAttributeView$lzy1"}, 
+    {"name":"hasUserDefinedFileAttributeView$lzy1"}, 
+    {"name":"jrtFs$lzy1"}, 
+    {"name":"random$lzy1"}, 
+    {"name":"supportedFileAttributeViews$lzy1"}
+  ]
+},
+{
+  "name":"sun.misc.Unsafe",
+  "fields":[{"name":"theUnsafe"}]
+},
+{
+  "name":"sun.security.pkcs12.PKCS12KeyStore",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.DSA$SHA224withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.DSA$SHA256withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.JavaKeyStore$DualFormatJKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.JavaKeyStore$JKS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA2$SHA224",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA2$SHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA5$SHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA5$SHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.X509Factory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.certpath.PKIXCertPathValidator",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.PSSParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSAKeyFactory$Legacy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSAPSSSignature",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA224withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA256withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA384withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.KeyManagerFactoryImpl$SunX509",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.util.ObjectIdentifier"
+},
+{
+  "name":"sun.security.x509.AuthorityInfoAccessExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.AuthorityKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.BasicConstraintsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.CRLDistributionPointsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.CertificateExtensions"
+},
+{
+  "name":"sun.security.x509.CertificatePoliciesExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.ExtendedKeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.IssuerAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.KeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.NetscapeCertTypeExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.PrivateKeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+}
+]

--- a/cmtc/src/main/resources/resource-config.json
+++ b/cmtc/src/main/resources/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":{
+  "includes":[{
+      "pattern":"\\Qnative/x86_64/libswoval-files0.dylib\\E"
+    }]},
+  "bundles":[]
+}

--- a/cmtc/src/main/scala/com/lunatech/cmt/client/command/Install.scala
+++ b/cmtc/src/main/scala/com/lunatech/cmt/client/command/Install.scala
@@ -210,7 +210,16 @@ object Install:
       private def downloadFile(fileUri: String, destination: ZipFile): Either[CmtError, Unit] =
         Try((new URL(fileUri) #> new File(destination.value.getAbsolutePath)).!) match {
           case Success(0) => Right(())
-          case _          => s"Failed to download asset: ${fileUri}".toExecuteCommandErrorMessage.asLeft
+          case Success(exitCode) =>
+            s"""Failed to download asset: ${fileUri}
+               |
+               |Command exit code = $exitCode
+               |""".stripMargin.toExecuteCommandErrorMessage.asLeft
+          case Failure(e) =>
+            s"""Failed to download asset: ${fileUri}
+               |
+               |${e.getStackTrace().mkString("\n")}
+               |""".stripMargin.toExecuteCommandErrorMessage.asLeft
         }
 
     end extension

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,11 +30,7 @@ object Build {
     Test / logBuffered := false)
 
   lazy val nativeImageSettings =
-    Seq(
-      nativeImageJvm := "graalvm-java17",
-      nativeImageVersion := "22.3.1",
-      nativeImageOptions := Seq("--no-fallback")
-    )
+    Seq(nativeImageJvm := "graalvm-java17", nativeImageVersion := "22.3.1", nativeImageOptions := Seq("--no-fallback"))
 
   lazy val commonBuildInfoKeys = Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,6 +2,9 @@ import sbt._
 import sbt.Keys._
 import sbtbuildinfo.BuildInfoKey
 import sbtbuildinfo.BuildInfoKeys._
+import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageJvm
+import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageOptions
+import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageVersion
 
 object Build {
 
@@ -25,6 +28,13 @@ object Build {
     buildInfoPackage := "com.lunatech.cmt.version",
     Test / parallelExecution := false,
     Test / logBuffered := false)
+
+  lazy val nativeImageSettings =
+    Seq(
+      nativeImageJvm := "graalvm-java17",
+      nativeImageVersion := "22.3.1",
+      nativeImageOptions := Seq("--no-fallback")
+    )
 
   lazy val commonBuildInfoKeys = Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,6 +5,7 @@ import sbtbuildinfo.BuildInfoKeys._
 import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageJvm
 import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageOptions
 import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageVersion
+import sbtnativeimage.NativeImagePlugin.autoImport.nativeImageAgentMerge
 
 object Build {
 
@@ -30,8 +31,17 @@ object Build {
     Test / logBuffered := false)
 
   lazy val nativeImageSettings =
-    Seq(nativeImageJvm := "graalvm-java17", nativeImageVersion := "22.3.1", nativeImageOptions := Seq("--no-fallback"))
-
+    Seq(
+      nativeImageAgentMerge := true,
+      nativeImageJvm := "graalvm-java17",
+      nativeImageVersion := "22.3.1",
+      nativeImageOptions :=
+        Seq(
+          "--no-fallback",
+          "--enable-url-protocols=https",
+          "-H:+ReportExceptionStackTraces",
+          s"-H:ReflectionConfigurationFiles=${(Compile / resourceDirectory).value / "reflect-config.json"}",
+          s"-H:ConfigurationFileDirectories=${(Compile / resourceDirectory).value}"))
   lazy val commonBuildInfoKeys = Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
 
   def buildKeysWithName(projectName: String): Seq[BuildInfoKey] =


### PR DESCRIPTION
This add some specific settings to try and generative native images. Mainly it does the following:

1. Add some extra settings to not create a fallback image, which needs a JVM to run. Now, if something is wrong and it can't generate a standalone image, it will fail
2. Restructure CI to not run formatting checks multiple times
3. Introduce mac to the os matrix to test image generation. In theory the dev dirs stuff is also a bit different on mac, so I kept running the tests on all 3 as well.