### PR TITLE
Bump sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4


### PR DESCRIPTION
- Bump sbt to 1.9.4
- Fixes [CVE-2022-46751](https://github.com/advisories/GHSA-2jc4-r94c-rp7h)